### PR TITLE
SQL - Add trigger between dossiers_openads and parcelles

### DIFF
--- a/openads/install/sql/openads/10_FUNCTION.sql
+++ b/openads/install/sql/openads/10_FUNCTION.sql
@@ -17,6 +17,35 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+-- ajout_modif_dossier()
+CREATE FUNCTION openads.ajout_modif_dossier() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    record_dossier record;
+BEGIN
+    SELECT INTO record_dossier
+        ARRAY_AGG("id_parcelles"::text) AS parcelles_id,
+        ST_Union(geom) AS geom
+    FROM openads.parcelles
+    WHERE "ident" = ANY (NEW.parcelles);
+    IF record_dossier.geom IS NOT NULL AND cardinality(record_dossier.parcelles_id) = cardinality(NEW.parcelles) THEN
+        RAISE NOTICE 'Insertion ou mise à jour dun dossier openads avec toutes les parcelles dans la base de données';
+        NEW.geom = ST_Multi(ST_CollectionExtract(ST_MakeValid(record_dossier.geom), 3));
+        NEW.x = ST_X(ST_PointOnSurface(NEW.geom));
+        NEW.y = ST_Y(ST_PointOnSurface(NEW.geom));
+    ELSE
+        RAISE NOTICE 'Insertion ou mise à jour dun dossier openads mais toutes les parcelles ne sont pas dans la base de données';
+        -- do nothing on geometry
+        NEW.x = NULL;
+        NEW.y = NULL;
+    END IF;
+
+RETURN NEW;
+END;
+$$;
+
+
 --
 -- PostgreSQL database dump complete
 --

--- a/openads/install/sql/openads/50_TRIGGER.sql
+++ b/openads/install/sql/openads/50_TRIGGER.sql
@@ -17,6 +17,10 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+-- dossiers_openads trg_add_update_dossier_openads
+CREATE TRIGGER trg_add_update_dossier_openads BEFORE INSERT OR UPDATE ON openads.dossiers_openads FOR EACH ROW EXECUTE PROCEDURE openads.ajout_modif_dossier();
+
+
 --
 -- PostgreSQL database dump complete
 --

--- a/openads/install/sql/openads/70_COMMENT.sql
+++ b/openads/install/sql/openads/70_COMMENT.sql
@@ -17,6 +17,10 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+-- FUNCTION ajout_modif_dossier()
+COMMENT ON FUNCTION openads.ajout_modif_dossier() IS 'Trigger pour l''ajout ou la modification d''un dossier pour la génération de la géométrie';
+
+
 -- communes
 COMMENT ON TABLE openads.communes IS 'Contient les communes';
 

--- a/openads/install/sql/upgrade/upgrade_to_0.1.1.sql
+++ b/openads/install/sql/upgrade/upgrade_to_0.1.1.sql
@@ -1,10 +1,45 @@
 BEGIN;
 
--- Convert Polygon to MultiPlygon
+-- Convert Polygon to MultiPolygon
 ALTER TABLE openads.dossiers_openads ALTER COLUMN geom TYPE geometry(MultiPolygon,2154) USING ST_Multi(geom);
 
 DROP TABLE IF EXISTS openads.dossiers_sig;
 
 ALTER TABLE ONLY openads.qgis_plugin ADD CONSTRAINT qgis_plugin_pkey PRIMARY KEY (id);
+
+-- Update geom from parcelles
+CREATE OR REPLACE FUNCTION openads.ajout_modif_dossier() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    record_dossier record;
+BEGIN
+    SELECT INTO record_dossier
+        ARRAY_AGG("id_parcelles"::text) AS parcelles_id,
+        ST_Union(geom) AS geom
+    FROM openads.parcelles
+    WHERE "ident" = ANY (NEW.parcelles);
+    IF record_dossier.geom IS NOT NULL AND cardinality(record_dossier.parcelles_id) = cardinality(NEW.parcelles) THEN
+        RAISE NOTICE 'Insertion ou mise à jour dun dossier openads avec toutes les parcelles dans la base de données';
+        NEW.geom = ST_Multi(ST_CollectionExtract(ST_MakeValid(record_dossier.geom), 3));
+        NEW.x = ST_X(ST_PointOnSurface(NEW.geom));
+        NEW.y = ST_Y(ST_PointOnSurface(NEW.geom));
+    ELSE
+        RAISE NOTICE 'Insertion ou mise à jour dun dossier openads mais toutes les parcelles ne sont pas dans la base de données';
+        -- do nothing on geometry
+        NEW.x = NULL;
+        NEW.y = NULL;
+    END IF;
+
+RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_add_update_dossier_openads
+BEFORE INSERT OR UPDATE ON openads.dossiers_openads
+FOR EACH ROW EXECUTE PROCEDURE openads.ajout_modif_dossier();
+
+COMMENT ON FUNCTION openads.ajout_modif_dossier()
+    IS 'Trigger pour l''ajout ou la modification d''un dossier pour la génération de la géométrie';
 
 COMMIT;

--- a/openads/tests/test_import.py
+++ b/openads/tests/test_import.py
@@ -19,6 +19,7 @@ from qgis.core import (
     QgsProviderRegistry,
     QgsVectorLayer,
 )
+from qgis.PyQt.QtCore import NULL
 
 from openads.processing.provider import OpenAdsProvider as ProcessingProvider
 from openads.qgis_plugin_tools import plugin_test_data_path
@@ -76,6 +77,77 @@ class TestImport(TestCasePlugin):
             self.connection.dropSchema(SCHEMA, True)
         del self.connection
         time.sleep(1)
+
+    def test_trigger_import_dossier(self):
+        """Test import trigger dossier."""
+        for i in (1, 2, 9):
+            self.connection.executeSql(
+                f"INSERT INTO openads.parcelles (ident, geom) "
+                f"VALUES ({i}, ST_Multi(ST_Buffer(ST_MakePoint({i},{i}), 10)));"
+            )
+
+        result = self.connection.executeSql(
+            "SELECT COUNT(*) AS count, STRING_AGG(\"id_parcelles\"::text, ',') FROM openads.parcelles;"
+        )[0]
+        self.assertEqual(3, result[0])
+        self.assertEqual("1,2,3", result[1])
+
+        count = self.connection.executeSql(
+            "SELECT COUNT(*) FROM openads.dossiers_openads;"
+        )[0][0]
+        self.assertEqual(0, count)
+
+        # Insertion d'un dossier avec des parcelles existantes dans la base
+        self.connection.executeSql(
+            "INSERT INTO openads.dossiers_openads (codeinsee, numero, parcelles) "
+            "VALUES ('25047', '2', array[2]);"
+        )
+        results = self.connection.executeSql("SELECT * FROM openads.dossiers_openads;")
+        self.assertEqual(1, len(results))
+        row = results[0]
+        self.assertEqual(row[0], 1)  # id_dossiers_openads
+        self.assertEqual(row[1], "25047")  # codeinsee
+        self.assertEqual(row[2], "2")  # numéro
+        self.assertEqual(row[3], "{2}")  # parcelles
+        self.assertGreaterEqual(row[4], 1)  # x
+        self.assertGreaterEqual(row[5], 1)  # y
+        self.assertNotEqual(row[7], NULL)  # geom
+        # self.connection.executeSql('TRUNCATE openads.dossiers_openads RESTART IDENTITY;')
+
+        # MAJ du dossier avec une parcelle non existante
+        self.connection.executeSql(
+            "UPDATE openads.dossiers_openads SET parcelles = array[2, 9999] "
+            "WHERE id_dossiers_openads = 1;"
+        )
+        results = self.connection.executeSql("SELECT * FROM openads.dossiers_openads;")
+        self.assertEqual(1, len(results))
+        row = results[0]
+        self.assertEqual(row[0], 1)  # id_dossiers_openads
+        self.assertEqual(row[1], "25047")  # codeinsee
+        self.assertEqual(row[2], "2")  # numéro
+        self.assertEqual(row[3], "{2,9999}")  # parcelles
+        self.assertEqual(row[4], NULL)  # x
+        self.assertEqual(row[5], NULL)  # y
+        self.assertNotEqual(row[7], NULL)  # geom
+        self.connection.executeSql(
+            "TRUNCATE openads.dossiers_openads RESTART IDENTITY;"
+        )
+
+        # Insertion d'un dossier avec des parcelles non existantes dans la base
+        self.connection.executeSql(
+            "INSERT INTO openads.dossiers_openads (codeinsee, numero, parcelles) "
+            "VALUES ('25047', '3', array[9999]);"
+        )
+        results = self.connection.executeSql("SELECT * FROM openads.dossiers_openads;")
+        self.assertEqual(1, len(results))
+        row = results[0]
+        self.assertEqual(row[0], 1)  # id_dossiers_openads
+        self.assertEqual(row[1], "25047")  # codeinsee
+        self.assertEqual(row[2], "3")  # numéro
+        self.assertEqual(row[3], "{9999}")  # parcelles
+        self.assertEqual(row[4], NULL)  # x
+        self.assertEqual(row[5], NULL)  # y
+        self.assertEqual(row[7], NULL)  # geom
 
     def test_import_constraints(self):
         """Test to import constraints in the database."""


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Ticket : 22
* SQL - Add trigger between dossiers_openads and parcelles

* Automatiser certaines étapes de la gestion des projets
  * lors de l'ajout ou la mise à jour d'un dossier_openads vérifier les parcelles
  * Si toutes les parcelles sont connus - modification des champs geom, x et y
  * Sinon - ne pas modifier le champs geom et passer à NULL les champs x et y
