### PR TITLE
GIS - Avoid touching polygons when importing constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Correction de l'import des contraintes qui pouvait que "toucher" les communes
+
 ## 0.10.0 - 2022-01-07
 
 * Suppression de la colonne `dossier_importe_geosig` dans la table `dossiers_openads`.

--- a/openads/processing/data/import_constraints.py
+++ b/openads/processing/data/import_constraints.py
@@ -1,4 +1,4 @@
-__copyright__ = "Copyright 2021, 3Liz"
+__copyright__ = "Copyright 2022, 3Liz"
 __license__ = "GPL version 3"
 __email__ = "info@3liz.org"
 
@@ -393,7 +393,6 @@ class ImportConstraintsAlg(BaseDataAlgorithm):
         sub_group: str,
     ) -> int:
         """Import in the database new geo-constraints."""
-        feedback.pushInfo("Insertion des géo-contraintes dans la base de données")
         success = 0
         fail = 0
         for feature in layer.getFeatures():
@@ -423,7 +422,7 @@ class ImportConstraintsAlg(BaseDataAlgorithm):
                 f"{schema}.contraintes "
                 f"WHERE "
                 f"libelle = {QgsExpression.quotedString(content_label)} "
-                f"AND texte = {QgsExpression.quotedString(content_text)}"
+                f"AND texte = {QgsExpression.quotedString(content_text)} "
                 f"AND groupe = {QgsExpression.quotedString(group)} "
                 f"AND sous_groupe = {QgsExpression.quotedString(sub_group)};"
             )


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Ticket : fix #15
* Avoid touching polygons when importing constraints
